### PR TITLE
adds node modules folder to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+node_modules


### PR DESCRIPTION
This pull request adds the node_modules folder to the .gitignore file. The purpose for the package.json and package-lock.json is to allow installing the
exact packages needed when the a project is cloned to work on.
